### PR TITLE
we need support custom headers

### DIFF
--- a/aliyun-api-gateway-demo-sign/com/aliyun/api/gateway/sdk/client.py
+++ b/aliyun-api-gateway-demo-sign/com/aliyun/api/gateway/sdk/client.py
@@ -51,6 +51,7 @@ class DefaultClient:
     def build_headers(self, request=None):
         headers = dict()
         header_params = request.get_headers()
+        headers.update(header_params)
         headers[constant.X_CA_TIMESTAMP] = DateUtil.get_timestamp()
         headers[constant.X_CA_KEY] = self.__app_key
 


### PR DESCRIPTION
for example:

```python
from com.aliyun.api.gateway.sdk import client
from com.aliyun.api.gateway.sdk.http import request
from com.aliyun.api.gateway.sdk.common import constant

host = "XXX"
url = "/user/login"
cli = client.DefaultClient(app_key="XXX", app_secret="XXX")
req_post = request.Request(host=host, protocol=constant.HTTPS, url=url, method="POST", time_out=30000, headers={"X-Ca-Stage": "TEST", "unitid": "123456789", "appkey": "XXX"})
body = '{"uri": "XXX", "phonenumber": "XXX", "verification_code": "XXX"}'
req_post.set_body(body)
req_post.set_content_type(constant.CONTENT_TYPE_STREAM)
print cli.execute(req_post)
```